### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ By mapping controllers or blocks to the desired applications, a listener object 
 
 ```ruby
 #inside your controller
-runner = Matrioska::AppRunner.new self
+runner = Matrioska::AppRunner.new(call)
 runner.map_app 3 do
   logger.info "hi there!"
 end


### PR DESCRIPTION
Matrioska::AppRunner.new expects a call, so from inside the controller, you should be passing the active call object (exposed as #call) rather than the controller itself.
