### PR TITLE
Needs to be a way to stop the runner

### DIFF
--- a/spec/matrioska/app_runner_spec.rb
+++ b/spec/matrioska/app_runner_spec.rb
@@ -37,6 +37,24 @@ module Matrioska
       it "should start the appropriate component" do
         call.should_receive(:write_and_await_response).with(input_component)
         subject.start
+        subject.status.should == :started
+      end
+    end
+
+    describe "#stop!" do
+      let(:mock_component) { double Punchblock::Component::Input, register_event_handler: true }
+
+      before do
+        Punchblock::Component::Input.stub(:new).and_return mock_component
+        call.stub(:write_and_await_response)
+        subject.start
+      end
+
+      it "stops the runner" do
+        mock_component.should_receive(:executing?).and_return true
+        mock_component.should_receive :stop!
+        subject.stop!
+        subject.status.should == :stopped
       end
     end
 


### PR DESCRIPTION
We need a `#stop` method to the [AppRunner](https://github.com/polysics/matrioska/blob/develop/lib/matrioska/app_runner.rb) that:
1. Clears the `@app_map`
2. Sets a instance variable `@stopped`, that other functions check before doing anything; maybe we could use `@running` for this purpose too, but that might be confusing to read.
3. Removes the Input component created [here](https://github.com/polysics/matrioska/blob/develop/lib/matrioska/app_runner.rb#L14-L19) ?  Or some other way to clear it... preferably something that removes it so there is no hanging input watcher after the runner is shut down..
