### PR TITLE
auto requiring dial_with_apps on load

### DIFF
--- a/lib/matrioska.rb
+++ b/lib/matrioska.rb
@@ -2,3 +2,4 @@ Matrioska = Module.new
 require "matrioska/version"
 require "matrioska/plugin"
 require "matrioska/app_runner"
+require "matrioska/dial_with_apps"

--- a/spec/matrioska/dial_with_apps_spec.rb
+++ b/spec/matrioska/dial_with_apps_spec.rb
@@ -1,7 +1,5 @@
 require 'spec_helper'
 
-require 'matrioska/dial_with_apps'
-
 describe Matrioska::DialWithApps do
   let(:call_id)           { SecureRandom.uuid }
   let(:call)              { Adhearsion::Call.new }


### PR DESCRIPTION
This will prevent explicit `require 'matrioska/dial_with_apps'`
