### PR TITLE
Check for call aliveness

### DIFF
--- a/lib/matrioska/app_runner.rb
+++ b/lib/matrioska/app_runner.rb
@@ -22,7 +22,7 @@ module Matrioska
       @component.register_event_handler Punchblock::Event::Complete do |event|
         handle_input_complete event
       end
-      @call.write_and_await_response @component if @call.active?
+      @call.write_and_await_response @component if @call.alive? && @call.active?
     end
 
     def stop!
@@ -87,7 +87,7 @@ module Matrioska
         logger.debug "MATRIOSKA #match_and_run called with #{digit}"
         callback = lambda do |call|
           @running = false
-          if call.active? && started?
+          if call.alive? && call.active? && started?
             logger.debug "MATRIOSKA CALLBACK RESTARTING LISTENER"
             start
           else


### PR DESCRIPTION
My scenario is that I have a B call that is executing a controller started by AppRunner. I set `call.auto_hangup = false` and do some post-processing in the controller. When the controller finishes, the actor has died and the callback fails when calling `call.active?`:

```
[2014-10-24 13:48:09.213] ERROR Adhearsion::OutboundCall: d8a710ef-3b3a-455c-be29-b78d6324ad6c@localhost: <Adhearsion::Call::ExpiredError> This call is expired and is no longer accessible. See http://adhearsion.com/docs/calls for further details.
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call.rb:28:in `rescue in method_missing'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call.rb:26:in `method_missing'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/matrioska-0.2.1/lib/matrioska/app_runner.rb:84:in `block in match_and_run'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call_controller.rb:113:in `call'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call_controller.rb:113:in `exec_with_callback'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call_controller.rb:105:in `block (2 levels) in bg_exec'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/foundation/exception_handler.rb:5:in `catching_standard_errors'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/adhearsion-2.5.4/lib/adhearsion/call_controller.rb:104:in `block in bg_exec'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/celluloid-0.15.2/lib/celluloid/thread_handle.rb:13:in `block in initialize'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/celluloid-0.15.2/lib/celluloid/internal_pool.rb:100:in `call'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/celluloid-0.15.2/lib/celluloid/internal_pool.rb:100:in `block in create'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/logging-1.8.2/lib/logging/diagnostic_context.rb:323:in `call'
        /usr/local/ruby_2.1.3/lib/ruby/gems/2.1.0/gems/logging-1.8.2/lib/logging/diagnostic_context.rb:323:in `block in create_with_logging_context'
```
