### PR TITLE
Fix failing specs with consistent request_id

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,9 @@ RSpec.configure do |config|
   config.before :suite do
     Adhearsion::Logging.start Adhearsion::Logging.default_appenders, :trace, Adhearsion.config.platform.logging.formatter
   end
+
+  config.before do
+    @uuid = SecureRandom.uuid
+    Punchblock.stub new_request_id: @uuid
+  end
 end


### PR DESCRIPTION
Some specs are failing[1] because the expected and returned input have different request ID's. Fixing by ensuring Punchblock always returns the same ID, as is done in the Punchblock specs[2].

[1] https://travis-ci.org/adhearsion/matrioska/builds/38971352
[2] https://github.com/adhearsion/punchblock/blob/develop/spec/spec_helper.rb#L28-31
